### PR TITLE
Groovy upgraded to fix CVE-2015-3253

### DIFF
--- a/groovy-parent/pom.xml
+++ b/groovy-parent/pom.xml
@@ -38,7 +38,7 @@
     <!--//////////////////// PROPERTIES ////////////////////-->
 
     <properties>
-        <groovy.version>2.4.3</groovy.version>
+        <groovy.version>2.4.4</groovy.version>
         <groovy-batch.version>2.4.3-01</groovy-batch.version>
         <groovy-compiler.version>2.9.2-01</groovy-compiler.version>
         <spock.version>1.0-groovy-2.4</spock.version>


### PR DESCRIPTION
Groovy needs to be upgraded to 2.4.4 to fix CVE-2015-3253

More information on this vulnerability:
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-3253
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3253

Groovy 2.4.4 changelogs:
http://www.groovy-lang.org/changelogs/changelog-2.4.4.html

Component upgraded:
org.codehaus.groovy:groovy 2.4.3 -> 2.4.4
